### PR TITLE
Load the RColorBrewer library

### DIFF
--- a/week2/EDA_plots_for_microarray.Rmd
+++ b/week2/EDA_plots_for_microarray.Rmd
@@ -47,6 +47,7 @@ Now the problem is obvious. It turns out this samples comes from an array for wh
 ```{r, fig.width=6, fig.height=3}
 ##we are doing this for two arrays 1 and 4
 library(matrixStats) ##need rowMedians
+library(RColorBrewer)
 for(i in c(1,4)){
   r=log2(int[,i])-rowMedians(log2(int)) 
   ## r are residuals from median array


### PR DESCRIPTION
Prevents the following error from occurring...

```
## Error: could not find function "brewer.pal"
```
