### PR TITLE
Fix the tutorial on installing software from github

### DIFF
--- a/week2/github.Rmd
+++ b/week2/github.Rmd
@@ -6,6 +6,6 @@ library(devtools)
 install_github("rafalib","ririzarr")
 library(rafalib)
 mypar
-shist(rnorm(100))
+shist(rnorm(100), 1)
 ```
 


### PR DESCRIPTION
Running this R markdown script causes an error, e.g.

```
## Error: object 'x' not found
```

Which is caused by the fact that the second parameter to
shist is 'unit = 0.5 \* sd(x)' which requires 'x' to exist. The
workaround is to explicitly set the unit to 1.
