### PR TITLE
Update distance.Rmd

### DIFF
--- a/course3/distance.Rmd
+++ b/course3/distance.Rmd
@@ -12,13 +12,13 @@ opts_chunk$set(fig.path=paste0("figure/", sub("(.*).Rmd","\\1",basename(knitr:::
 
 The concept of distance can be generalized from  physical distance. For example, we cluster animals into groups. When we do this, we put animals that "close" in the same group:
 
-<img src="images/animals.png" align="middle" width=300>
+<img src="images/animals.png" align="middle" width="300">
 
 Any time we cluster individuals into separate groups we are, explicitely or implicitely computing a distance. 
 
 Do create _heatmaps_ a distance is computed explicitely. Heatmaps are widely used in genomics and other highthroughput fields:
 
-<img src="images/Heatmap.png" align="middle" width=300>
+<img src="images/Heatmap.png" align="middle" width="300">
 Image Source: Heatmap, Gaeddal, 01.28.2007, http://commons.wikimedia.org/wiki/File:Heatmap.png, PD
 
 In these plots the measurements, which are stored in a matrix, are represented with colors after the columns and rows have been clustered. Here we will learn the necessary mathematics and computing skill to understand and create heatmaps. We start by reviewing the mathematical definition of distance. 


### PR DESCRIPTION
The edit might look like it's nothing, but I actually replaced the left-quotes with regular quotes on the two image html tags at the beggining of the file, because they were causing a bug which made the HTML tag escaped after the .rmd was knit (tested on IE and Chrome). Note that the bug is not present at the .Rmd preview here on Github. Just check the current book status on http://genomicsclass.github.io/book/pages/distance.html, the first two images aren't shown. Also, the width parameters did not have the quotes. I made some testing and this should fix the problem.