### PR TITLE
Update matrix_operations.Rmd

### DIFF
--- a/course2/matrix_operations.Rmd
+++ b/course2/matrix_operations.Rmd
@@ -15,11 +15,11 @@ opts_chunk$set(fig.path=paste0("figure/", sub("(.*).Rmd","\\1",basename(knitr:::
 
 In the previous section we motivated the use of matrix algebra with this system of equations:
 
-$$\begin{eqnarray}
-a + b + c &=& 6\\
-3a - 2b + c &=& 2\\
-2a + b  - c &=& 1
-\end{eqnarray}
+$$\begin{aligned}
+a + b + c &= 6\\
+3a - 2b + c &= 2\\
+2a + b  - c &= 1
+\end{aligned}
 $$
 
 We described how this system can be rewritten and solved using matrix algebra:


### PR DESCRIPTION
The first group of equations was aligned using `eqnarray`, which didn't work well for me when converted to pdf using pandoc. Using `aligned` fixed it, along with removing the second ampersand of each equation (just like the equations at line 139).