### PR TITLE
more explains in different pvalue estimation in T-test-practice

### DIFF
--- a/inference/t-tests_in_practice.Rmd
+++ b/inference/t-tests_in_practice.Rmd
@@ -137,7 +137,19 @@ approximation takes into account that the denominator (the standard
 error of the difference) is a random variable. The smaller the
 sample size, the more the denominator varies. 
 
+
 It may be confusing that one approximation gave us one p-value and another gave us another, because we expect there to be just one answer. However, this is not uncommon in data analysis. We used different assumptions, different approximations, and therefore we obtained different results.
+
+Specifically in this example, we calculate pvalue manually using normal distribution (`pnorm`), while `t.test` using t distribution (`pt`). By default `t.test` using `Welch Two Sample t-test` which is even more conserved than `Standard Student's t-test` without equal variance assumption.
+
+
+Using `pt` to calculate pvalue will equals to `Standard Student's t-test`.
+
+```{r}
+2*(1-pt(tstat, df=length(treatment)+length(control)-2))
+t.test(treatment, control, var.equal=T)
+```
+
 
 Later, in the power calculation section, we will describe type I and
 type II errors. As a preview, we will point out that the test based on

--- a/inference/t-tests_in_practice.Rmd
+++ b/inference/t-tests_in_practice.Rmd
@@ -140,7 +140,7 @@ sample size, the more the denominator varies.
 
 It may be confusing that one approximation gave us one p-value and another gave us another, because we expect there to be just one answer. However, this is not uncommon in data analysis. We used different assumptions, different approximations, and therefore we obtained different results.
 
-Specifically in this example, we calculate pvalue manually using normal distribution (`pnorm`), while `t.test` using t distribution (`pt`). By default `t.test` using `Welch Two Sample t-test` which is even more conserved than `Standard Student's t-test` without equal variance assumption.
+Specifically in this example, we calculate pvalue manually using normal distribution (`pnorm`), while `t.test` using t distribution (`pt`). By default `t.test` using `Welch Two Sample t-test` which is even more conserved than `Standard Student's t-test` without equal variance assumption. This is why we obtained different pvalues.
 
 
 Using `pt` to calculate pvalue will equals to `Standard Student's t-test`.

--- a/matrixalg/matrix_operations.Rmd
+++ b/matrixalg/matrix_operations.Rmd
@@ -161,7 +161,7 @@ Here is a simple example. We can check to see if `abc=c(3,2,1)` is a solution:
 ```{r}
 X  <- matrix(c(1,3,2,1,-2,1,1,1,-1),3,3)
 abc <- c(3,2,1) #use as an example
-rbind( sum(X[1,]*abc), sum(X[2,]*abc), sum(X[3,]%*%abc))
+rbind( sum(X[1,]*abc), sum(X[2,]*abc), sum(X[3,]*abc))
 ```
 
 We can use the `%*%` to perform the matrix multiplication and make this much more compact:


### PR DESCRIPTION
Dear Rafa,

The explanation of different pvalue in t-test-practice is good.
>The p-value is slightly bigger now. This is to be expected because our CLT approximation considered the denominator of tstat practically fixed (with large samples it practically is), while the t-distribution approximation takes into account that the denominator (the standard error of the difference) is a random variable. The smaller the sample size, the more the denominator varies.
>
>It may be confusing that one approximation gave us one p-value and another gave us another, because we expect there to be just one answer. However, this is not uncommon in data analysis. We used different assumptions, different approximations, and therefore we obtained different results.

But I think students may still got confused. In my opinion, it would be better to elaborate how the difference came from with the example as you pointed out due to different assumptions/approximations. And also present that we can obtained identical result with identical assumption/approximation.

Bests,
Guangchuang
