### PR TITLE
corrected numer value for variance on RHS of eqn

### DIFF
--- a/modeling/bayes.Rmd
+++ b/modeling/bayes.Rmd
@@ -209,7 +209,13 @@ The variance can be shown to be:
 
 $$
 \mbox{var}(\theta\mid y) = \frac{1}{1/\sigma^2+1/\tau^2}
-= \frac{1}{1/.110^2 + 1/.027^2} = 0.026
+= \frac{1}{1/.110^2 + 1/.027^2} = 0.00069 
+
+$$
+and in this case the standard deviation is:
+$$
+\mbox{sd}(\theta\mid y) = sqrt(var(\theta\mid y) = 0.026 
+
 $$
 
 So we started with a frequentist 95% confidence interval that ignored data from other players and summarized just José's data: .450 $\pm$ 0.220. Then we used an Bayesian approach that incorporated data from other players and other years to obtain a posterior probability. This is actually referred to as an empirical Bayes approach because we used data to construct the prior. From the posterior we can report what is called a 95% credible interval by reporting a region, centered at the mean, with a 95% chance of occurring. In our case, this turns out to be: .285 $\pm$ 0.052.


### PR DESCRIPTION
The latex code in Bayes.Rmd also contains some errors or inconsistencies (w.r.t use of preceding 0.) in the line 299 around "\mbox{E}(\theta \mid Y=450) &\approx .285 "

...where numbers are plugged in to calculate B,: Here you use 0.110 and not 0.111. A tiny error but still confusing to a learner.

Also the bayes.Rmd says: var(theta | y) can be shown to be ... = 0.026.

IMHO the standard deviation sd (theta | y) should be the sqare root of this: sqrt(0.026) = 0.1612.

but at the end of the paragraph below you say the 95% credible interval:

    this turns out to be: .285 ± 0.052.

I though confidence intervals at the 95% level are approx. SDs wide. Are 95%-level credible-intervals two variances wide?

Shouldn't this be two SDs wide: 2* 0.162 = 0.3225 - but this would still be meaningless (because the E(Theta | Y) = 0.285 < 0.3225

Ahh I see the video uses the correct values var = 0.00069, => sqrt(var) = 0.026