### PR TITLE
Replace deprecated functions; typo fixes

### DIFF
--- a/methyl/inference_for_DNAmeth.Rmd
+++ b/methyl/inference_for_DNAmeth.Rmd
@@ -13,10 +13,11 @@ library(minfi) ##Bioc
 library(IlluminaHumanMethylation450kmanifest) ##Bioc
 library(doParallel) ##CRAN
 library(pkgmaker)
+library(rafalib)
 ```
 
 ```{r}
-path="/Users/ririzarr/myDocuments/teaching/HarvardX/tcgaMethylationSubset"
+path="/Users/ririzarr/myDocuments/teaching/HarvardX/tcgaMethylationSubset"    # use your own path to downloaded data
 targets=read.delim(file.path (path,"targets.txt"),as.is=TRUE)
 table(targets$Tissue,targets$Status)
 ```
@@ -29,7 +30,7 @@ targets = targets[index,]
 ```
 
 ```{r}
-dat = read.450k.exp(base=path,targets = targets, verbose=TRUE)
+dat = read.metharray.exp(base=path,targets = targets, verbose=TRUE)
 dat = preprocessIllumina(dat)
 dat = mapToGenome(dat)
 dat = ratioConvert(dat,type="Illumina")
@@ -62,14 +63,14 @@ tab = res$tab[res$tab$fwer <= 0.05,]
 tab = makeGRangesFromDataFrame(tab,keep.extra.columns = TRUE)
 
 map=distanceToNearest(tab,cgi)
-d = mcols(map)$dist
-prop.table( table( cut(d,c(0,1,2000,5000,Inf),include.lowest=TRUE,right=FALSE) ))
+d = mcols(map)$distance
+prop.table( table( cut(as.numeric(d),c(0,1,2000,5000,Inf),include.lowest=TRUE,right=FALSE) ))
 
 null =  granges(dat)
 nulltab = makeGRangesFromDataFrame(null,keep.extra.columns = TRUE)
 
 nullmap=distanceToNearest(nulltab,cgi)
-nulld = mcols(nullmap)$dist
+nulld = mcols(nullmap)$distance
 prop.table( table( cut(nulld,c(0,1,2000,5000,Inf),include.lowest=TRUE,right=FALSE) ))
 ```
 
@@ -79,7 +80,7 @@ cols = as.factor(pData(dat)$Tissue)
 
 tab = tab[order(-mcols(tab)$area)]
 tab = tab+3000 ##add 3000 to each side
-mypar2(1,1)
+mypar(1,1)
 i=17
 dataIndex = which(granges(dat)%over%tab[i])
 cgiIndex = which(cgi%over%tab[i])

--- a/methyl/methylation.Rmd
+++ b/methyl/methylation.Rmd
@@ -26,7 +26,7 @@ dim(pd) ##this is sample information
 length(gr)
 ```
 
-The pd object includes clinical information. One the coluumns tells us if the sample is from colon cancer or from normal tissue
+The `pd` object includes clinical information. One the columns tells us if the sample is from colon cancer or from normal tissue
 
 ```{r}
 colnames(pd)
@@ -36,7 +36,7 @@ cancerlIndex <- which(pd$Status=="cancer")
 ```
 
 
-Let's start by taking a quick look at the distribution of methylation measurements for the normal samples
+Let's start by taking a quick look at the distribution of methylation measurements for the normal samples:
 
 ```{r}
 i=normalIndex[1]
@@ -50,23 +50,23 @@ for(i in cancerlIndex){
 }
 ```
 
-We are interested in finding regions of the genome that are different between cancer and normal samples. Furthermore, we want regions that are consistenly different therefore we can treat this as an inference problem. We can compute a t-statistic for each CpG
+We are interested in finding regions of the genome that are different between cancer and normal samples. Furthermore, we want regions that are consistenly different therefore we can treat this as an inference problem. We can compute a t-statistic for each CpG:
 
 ```{r,message=FALSE}
 library(limma)
 X<-model.matrix(~pd$Status)
 fit<-lmFit(meth,X)
-eb <- ebayes(fit)
+eb <- eBayes(fit)
 ```
 
-A volcano plot reveals many differences
+A volcano plot reveals many differences:
 
 ```{r}
 library(rafalib)
 splot(fit$coef[,2],-log10(eb$p.value[,2]),xlab="Effect size",ylab="-log10 p-value")
 ```
 
-If we have reason to believe for DNA methylation to have an effect on gene expression a region of the genome needs to be affected, not just a single CpG, we should look beyond. Here is plot of the region surrounding the top hit
+If we have reason to believe for DNA methylation to have an effect on gene expression a region of the genome needs to be affected, not just a single CpG, we should look beyond. Here is plot of the region surrounding the top hit:
 
 ```{r,message=FALSE}
 library(GenomicRanges)
@@ -81,7 +81,7 @@ plot(pos[Index],fit$coef[Index,2],type="b",xlab="genomic location",ylab="differe
 matplot(pos[Index],meth[Index,],col=cols,xlab="genomic location")
 ```
 
-We can search for these regions explicitely, instead of searching for single points as explained by Jaffe and Irizarry (2012) [http://www.ncbi.nlm.nih.gov/pubmed/22422453]. 
+We can search for these regions explicitly instead of searching for single points, as explained by Jaffe and Irizarry (2012) [http://www.ncbi.nlm.nih.gov/pubmed/22422453]. 
 
 If we are going to perform regional analysis we first have to define a region. But one issue is that not only do we have to separate the analysis by chromosome but that within each chromosome we usually have big gaps creating subgroups of regions to be analyzed.
 
@@ -93,14 +93,14 @@ hist(log10(diff(pos[chr1Index])),main="",xlab="log 10 method")
 We can create groups in the following way.
 
 ```{r,message=FALSE}
-# biocLite("bumphunter")
+# BiocManager::install("bumphunter")
 library(bumphunter)
 cl=clusterMaker(chr,pos,maxGap=500)
 table(table(cl)) ##shows the number of regions with 1,2,3, ... points in them
 ```
 
 
-Now let's consider two example regions
+Now let's consider two example regions:
 
 ```{r}
 ###Select the region with the smallest value
@@ -114,7 +114,7 @@ abline(h=0,lty=2)
 abline(h=c(-.1,.1),lty=2)
 ```
 
-This region shows only a single CpG as different. In contrast notice this region:
+This region shows only a single CpG as different. In contrast, notice this region:
 
 ```{r}
 Index=which(cl==72201) ##we know this is a good example from analysis we have already performed
@@ -145,14 +145,14 @@ lines(x2,lfit$fitted,col=2)
 ```
 
 
-The bumphunter automates this procedure
+The bumphunter automates this procedure:
 
 ```{r}
 res<-bumphunter(meth,X,chr=chr,pos=pos,cluster=cl,cutoff=0.1,B=0)
 tab<-res$table
 ```
 
-We now have a list of regions instead of single points. Here we look at the region with the highest rank if we order by area
+We now have a list of regions instead of single points. Here we look at the region with the highest rank if we order by area:
 
 ```{r}
 Index=(tab[1,7]-3):(tab[1,8]+3)

--- a/methyl/minfi.Rmd
+++ b/methyl/minfi.Rmd
@@ -11,8 +11,7 @@ opts_chunk$set(fig.path=paste0("figure/", sub("(.*).Rmd","\\1",basename(knitr:::
 In this unit we will demonstrate how to read idat files from the illumina 450K DNA methylation array. We make use the the Bioconductor minfi package [cite 24478339]
 
 ```{r}
-# source("http://www.bioconductor.org/biocLite.R")
-# biocLite(c("minfi","IlluminaHumanMethylation450kmanifest","IlluminaHumanMethylation450kanno.ilmn12.hg19"))
+# BiocManager::install(c("minfi","IlluminaHumanMethylation450kmanifest","IlluminaHumanMethylation450kanno.ilmn12.hg19"))
 library(minfi)
 ```
 
@@ -35,11 +34,11 @@ To make this script work in any working directory  we can edit that column to co
 
 ```{r}
 targets$Basename <- file.path(path,targets$Basename)
-rgset <- read.450k(targets$Basename,verbose=TRUE)
+rgset <- read.metharray(targets$Basename,verbose=TRUE)
 pData(rgset)<-targets
 ```
 
-We now have the raw data, red an green intensities which we have access too
+We now have the raw data, red and green intensities which we have access to:
 ```{r}
 dim(getRed(rgset))
 dim(getGreen(rgset))
@@ -51,7 +50,7 @@ If you are not interested in developing preprocessing algorithms then you can us
 mset <- preprocessIllumina(rgset)
 ```
 
-This performs the default preprocessing algorithm developed by Illumina. However, for this to be useful we want to have the locations of each CpG and to do that we need map the CpGs to genome. Minfi keeps this information modular so that when the genome annotation gets updated one can easilty change the mapping. 
+This performs the default preprocessing algorithm developed by Illumina. However, for this to be useful we want to have the locations of each CpG and to do that we need map the CpGs to genome. minfi keeps this information modular so that when the genome annotation gets updated one can easilty change the mapping. 
 ```{r}
 mset <- mapToGenome(mset)
 ```


### PR DESCRIPTION
I made a variety of small changes to `methyl/methylation.Rmd` and `methyl/minfi.Rmd`.

 - `biocLite` calls are replaced with `BiocManager::install`
 - `read.450k` replaced with `read.metharray`
 - `ebayes` replaced with `eBayes`
 - several small copy edits

There remains a problem with `methyl/minfi.Rmd` that I will file separately as an issue.

Thanks!