### PR TITLE
Replace biocLite w BiocManager in RNAseq links

### DIFF
--- a/rnaseq/r_bioc_links.md
+++ b/rnaseq/r_bioc_links.md
@@ -4,11 +4,10 @@
 * [RStudio](http://www.rstudio.com/)
 * [Bioconductor](http://bioconductor.org/install)
 
-Once you have installed R, running the following lines in your console will install Bioconductor:
+Once you have installed R and the `BiocManager` package, running the following lines in your console will install Bioconductor:
 
 ```
-source("http://bioconductor.org/biocLite.R")
-biocLite()
+BiocManager::install()
 ```
 
 Make sure to hit `[a]` to update all packages. This is important so that your answers will match the answers accepted by the grading bot.
@@ -16,15 +15,14 @@ Make sure to hit `[a]` to update all packages. This is important so that your an
 To install specific packages from Bioconductor use, for example:
 
 ```
-biocLite(c("pasilla","DEXSeq"))
+BiocManager::install(c("pasilla", "DEXSeq"))
 ```
 
-We will provide a list of all packages we will use [here]().
+We will provide a list of all packages we will use [here](rnaseq_pkgs.R).
 
-If you want to see what version of Biocondutor you are using and whether your packages are up to date:
+If you want to see what version of Bioconductor you are using and whether your packages are up to date:
 
 ```
-library(BiocInstaller)
-biocVersion()
-biocValid()
+BiocManager::version()
+BiocManager::valid()
 ```


### PR DESCRIPTION
Replacing old `biocLite` calls in this Rmd since it's linked in PH525x. 

Separate from this pull request - 
Looks like `biocLite` is still scattered around Rmds in the repo. 
Should I just replace this everywhere?

```
dspkimesmacport-2:labs pkimes$ grep "biocLite" */*.R*  | cut -f1 -d: | uniq -c
   1 Rscripts/limma_quiz.R
   1 Rscripts/microarraydata-eda-lab.R
   3 advinference/quick_Bioc_intro.Rmd
   2 bioc/gene_set_analysis.Rmd
   2 bioc/gene_set_analysis_in_R.Rmd
   1 bioc/using_limma.Rmd
   5 bioc/visualizing_NGS.Rmd
   1 biocadv_6x/bioc2_nosql.Rmd
   1 biocadv_6x/bioc2_vizNGS.Rmd
   1 chipseq/ChIPseq.Rmd
   1 methyl/epiviz.Rmd
   6 variants/SNP.Rmd
```