### PR TITLE
Correct rendering of pd object

### DIFF
--- a/methyl/methylation.Rmd
+++ b/methyl/methylation.Rmd
@@ -13,7 +13,8 @@ In this unit we will show an example of analyzing methylation data. We will use 
 
 Let's begin by loading the data
 ```{r,message=FALSE}
-# devtools::install_github("coloncancermeth/genomicsclass")
+# devtools::install_github("genomicsclass/coloncancermeth")
+library(S4Vectors)
 library(coloncancermeth)
 data(coloncancermeth)
 ```


### PR DESCRIPTION
Adding `library(S4Vectors)` call so that `pd` renders correctly in the knit document. Also correcting the GitHub repo name for genomicsclass/coloncancermeth - repo/username were backwards.